### PR TITLE
Remove progressoptions; require PkgBenchmark >= 0.2.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 [compat]
 CpuId = "0.2"
 JSON = "0.21"
-PkgBenchmark = "0.2"
+PkgBenchmark = "0.2.8"
 Setfield = "0.1, 0.2, 0.3, 0.4, 0.5, 0.6"
 julia = "1"
 

--- a/src/BenchmarkCI.jl
+++ b/src/BenchmarkCI.jl
@@ -103,7 +103,6 @@ function judge(
     pkgdir = pwd(),
     script = joinpath(pkgdir, "benchmark", "benchmarks.jl"),
     project = dirname(script),
-    progressoptions = is_in_ci() ? (dt = 60 * 9.0,) : NamedTuple(),
 )
     target = BenchmarkConfig(target)
     if !(baseline isa BenchmarkConfig)
@@ -125,7 +124,6 @@ function judge(
             workspace = workspace,
             pkgdir = pkgdir,
             benchmarkpkg_kwargs = (
-                progressoptions = progressoptions,
                 script = script_wrapper,
             ),
         )


### PR DESCRIPTION
an alternative to #40.