### PR TITLE
Fix .mergify.yml; do not use status-success~=

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        # Edit ../../.mergify.yml when adding a new version.
         julia-version: ['1.4', 'nightly']
       fail-fast: false
     name: Test Julia ${{ matrix.julia-version }}

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,8 +8,7 @@ pull_request_rules:
     conditions:
       - base=master
       - "#approved-reviews-by>=1"
-      - status-success~=Test Julia .*
-      - -status-failure~=Test Julia [0-9].*
+      - status-success=Test Julia 1.4
       - status-success=Benchmark
       - label=ready-to-merge:squash
       - label!=work-in-progress
@@ -20,8 +19,7 @@ pull_request_rules:
     conditions:
       - base=master
       - "#approved-reviews-by>=1"
-      - status-success~=Test Julia .*
-      - -status-failure~=Test Julia [0-9].*
+      - status-success=Test Julia 1.4
       - status-success=Benchmark
       - label=ready-to-merge:rebase
       - label!=work-in-progress
@@ -32,8 +30,7 @@ pull_request_rules:
     conditions:
       - base=master
       - "#approved-reviews-by>=1"
-      - status-success~=Test Julia .*
-      - -status-failure~=Test Julia [0-9].*
+      - status-success=Test Julia 1.4
       - status-success=Benchmark
       - label=ready-to-merge:merge
       - label!=work-in-progress
@@ -44,8 +41,7 @@ pull_request_rules:
     conditions:
       - author=tkf
       - base=master
-      - status-success~=Test Julia .*
-      - -status-failure~=Test Julia [0-9].*
+      - status-success=Test Julia 1.4
       - status-success=Benchmark
       - label~=ready-to-merge:.*
     actions:


### PR DESCRIPTION
## Commit Message
Fix .mergify.yml; do not use status-success~= (#75)

It does not wait for all match. See also:
https://doc.mergify.io/conditions.html#validating-all-status-check
https://github.com/JuliaFolds/DataTools.jl/pull/6