### PR TITLE
Update example action in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
-          version: 1.4
+          version: 1
+      - uses: julia-actions/julia-buildpkg@latest
       - name: Install dependencies
         run: julia -e 'using Pkg; pkg"add PkgBenchmark BenchmarkCI@0.1"'
       - name: Run benchmarks
@@ -69,7 +70,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
-          version: 1.4
+          version: 1
+      - uses: julia-actions/julia-buildpkg@latest
       - name: Install dependencies
         run: julia -e 'using Pkg; pkg"add PkgBenchmark BenchmarkCI@0.1"'
       - name: Run benchmarks


### PR DESCRIPTION
I recently came across a problem with running BenchmarkCI with a package that has binary dependencies. Turns out you need to run the `julia-actions/julia-buildpkg@latest` step in the action, or dependencies don't get built.

I updated the action listed in the README to reflect this, so other people don't run into this problem.

I also changed the Julia version from 1.4 to 1, so it doesn't go out of date.